### PR TITLE
removed colon to avoid GitHub parse error

### DIFF
--- a/src/generate-report.ts
+++ b/src/generate-report.ts
@@ -22,7 +22,7 @@ const parse = (object: reportTypes.zapObject): reportTypes.report => {
           helpUri: `https://www.zaproxy.org/docs/alerts/${alert.alertRef}`,
           defaultConfiguration: {level: severity},
           properties: {
-            tags: [ `external/cwe/cwe-${alert.cweid}`]
+            tags: [`external/cwe/cwe-${alert.cweid}`]
           }
         }
       })
@@ -69,6 +69,7 @@ const parse = (object: reportTypes.zapObject): reportTypes.report => {
                   uri: instance.uri
                     .replace(/(^\w+:|^)\/\//, '')
                     .replace(/\/$/, '')
+                    .replace(/:/g, '')
                 },
                 region: {
                   startLine: 1


### PR DESCRIPTION
GitHub would display 'Analysis parse error' when physical URL had colon character used in port specification.  This does not impact the valid URLs included in the message text field.